### PR TITLE
Chore re-arrange installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Make `clang++` available first.
 You need `freeglut` and `xquartz` to build. To install them through `homebrew`, issue below.
 
 ```bash
-$ brew install freeglut
 $ brew cask install xquartz
+$ brew install freeglut
 
 $ export DISPLAY=:0.0
 ```


### PR DESCRIPTION
To install freeglut, xquartz must be installed before.